### PR TITLE
Add Quad Nerdle: 4 equations in 10 tries, distinct quads, stratified MC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@ generate_maxi
 solve
 solve_adaptive
 solve_binerdle
+solve_quadnerdle
 bench_nerdle
 bench_binerdle
 nerdle
 binerdle
+quadnerdle
+bench_quadnerdle
 test_fb
 
 # Generated data (run ./generate or ./generate_maxi to create)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINDIR = .
 
 .PHONY: all clean
 
-all: generate generate_maxi solve solve_adaptive solve_binerdle bench_nerdle nerdle binerdle bench_binerdle
+all: generate generate_maxi solve solve_adaptive solve_binerdle solve_quadnerdle bench_nerdle nerdle binerdle bench_binerdle quadnerdle bench_quadnerdle
 
 generate: $(SRCDIR)/generate.cpp
 	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
@@ -23,6 +23,9 @@ solve_adaptive: $(SRCDIR)/solve_adaptive.cpp
 solve_binerdle: $(SRCDIR)/solve_binerdle.cpp
 	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
 
+solve_quadnerdle: $(SRCDIR)/solve_quadnerdle.cpp
+	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
+
 bench_nerdle: $(SRCDIR)/bench_nerdle.cpp
 	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
 
@@ -35,8 +38,14 @@ binerdle: $(SRCDIR)/binerdle.cpp
 bench_binerdle: $(SRCDIR)/bench_binerdle.cpp
 	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
 
+quadnerdle: $(SRCDIR)/quadnerdle.cpp
+	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
+
+bench_quadnerdle: $(SRCDIR)/bench_quadnerdle.cpp
+	$(CXX) $(CXXFLAGS) -fopenmp -o $(BINDIR)/$@ $<
+
 clean:
 	rm -f $(BINDIR)/generate $(BINDIR)/generate_maxi $(BINDIR)/solve \
-	      $(BINDIR)/solve_adaptive $(BINDIR)/solve_binerdle \
+	      $(BINDIR)/solve_adaptive $(BINDIR)/solve_binerdle $(BINDIR)/solve_quadnerdle \
 	      $(BINDIR)/bench_nerdle $(BINDIR)/nerdle $(BINDIR)/binerdle \
-	      $(BINDIR)/bench_binerdle
+	      $(BINDIR)/bench_binerdle $(BINDIR)/quadnerdle $(BINDIR)/bench_quadnerdle

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nerdle Solver
 
-Entropy-based solver for [Nerdle](https://www.nerdlegame.com/) and [Binerdle](https://www.nerdlegame.com/binerdle.html). Supports Micro (5-tile), Mini (6), Midi (7), Classic (8-tile) Nerdle, plus Binerdle Mini (6) and Normal (8).
+Entropy-based solver for [Nerdle](https://www.nerdlegame.com/), [Binerdle](https://www.nerdlegame.com/binerdle.html), and [Quad Nerdle](https://www.nerdlegame.com/quadnerdle.html). Supports Micro (5-tile), Mini (6), Midi (7), Classic (8-tile) Nerdle, plus Binerdle Mini (6) and Normal (8), and Quad Nerdle (4 equations in 10 tries).
 
 ---
 
@@ -38,6 +38,11 @@ make                           # build C++ tools
 ./binerdle --len 8             # normal, interactive player
 ./bench_binerdle data/equations_6.txt
 ./bench_binerdle data/equations_8.txt
+
+# Quad Nerdle (guess 4 equations in 10 tries)
+./solve_quadnerdle data/equations_8.txt   # optimal 1st guess (stratified, --no-stratify for plain)
+./quadnerdle --len 8                      # interactive player
+./bench_quadnerdle data/equations_8.txt   # benchmark (sampled distinct quadruples)
 ```
 
 ---
@@ -53,6 +58,9 @@ make                           # build C++ tools
 | Binerdle optimal 1st | `./solve_binerdle data/equations_6.txt` |
 | Binerdle interactive | `./binerdle --len 6` or `--len 8` |
 | Binerdle benchmark | `./bench_binerdle data/equations_6.txt` |
+| Quad Nerdle optimal 1st | `./solve_quadnerdle data/equations_8.txt` |
+| Quad Nerdle interactive | `./quadnerdle --len 8` |
+| Quad Nerdle benchmark | `./bench_quadnerdle data/equations_8.txt` |
 
 ---
 
@@ -124,7 +132,7 @@ Press Enter to use the suggested guess, or type your own. Type `y` when you solv
 
 ### 4. Binerdle (`binerdle`)
 
-Guess 2 Nerdle equations in 7 tries. **One guess per turn** applies to both; you get separate feedback for each equation.
+Guess 2 Nerdle equations in 7 tries. **One guess per turn** applies to both; you get separate feedback for each equation. The two equations are always distinct. Uses stratified sampling when the candidate pair space is large.
 
 ```bash
 ./binerdle --len 6     # mini (6-tile equations)
@@ -135,7 +143,19 @@ Enter feedback for each equation (G/P/B or `y` if correct). You can override the
 
 ---
 
-### 5. Benchmark (`bench_nerdle`)
+### 5. Quad Nerdle (`quadnerdle`)
+
+Guess 4 Nerdle equations in 10 tries. **One guess per turn** applies to all four; you get separate feedback for each equation. All 4 equations are always distinct. Uses stratified Monte Carlo for entropy when the candidate space is large.
+
+```bash
+./quadnerdle --len 8
+```
+
+Enter feedback for each of the 4 equations (G/P/B or `y` if correct). Recommended first guess: **1\*15-9=6** (Quad-optimal) or **43-27=16** (Binerdle optimal). Run `./solve_quadnerdle data/equations_8.txt` to recompute.
+
+---
+
+### 6. Benchmark (`bench_nerdle`)
 
 ```bash
 ./bench_nerdle data/equations_8.txt
@@ -146,7 +166,7 @@ Simulates the solver against all equations and reports mean/max guesses and dist
 
 ---
 
-### 6. Binerdle benchmark (`bench_binerdle`)
+### 7. Binerdle benchmark (`bench_binerdle`)
 
 ```bash
 ./bench_binerdle data/equations_6.txt   # mini
@@ -154,6 +174,19 @@ Simulates the solver against all equations and reports mean/max guesses and dist
 ```
 
 Simulates Binerdle with one shared guess per turn. Reports mean guesses and distribution. Turns = when both equations are identified (effectively max of the two "virtual" identification times).
+
+---
+
+### 8. Quad Nerdle benchmark (`bench_quadnerdle`)
+
+```bash
+./bench_quadnerdle data/equations_8.txt
+./bench_quadnerdle data/equations_8.txt --sample 10000
+./bench_quadnerdle data/equations_8.txt --single    # use 48-32=16 as first guess
+./bench_quadnerdle data/equations_8.txt --binerdle  # use 43-27=16 as first guess
+```
+
+Simulates Quad Nerdle over **sampled distinct** quadruples (all 4 equations different). Default 5000 samples. Compare single vs Binerdle first guess with `--single` / `--binerdle`.
 
 ---
 
@@ -197,12 +230,22 @@ make clean        # remove binaries
 | 8 (classic) | 48-32=16 | 9.78 bits |
 | 10 (maxi) | 76+1-23=54 | 12.82 bits |
 
-**Binerdle (pair space):**
+**Binerdle (pair space, distinct equations):**
 
 | Length | First guess | Notes |
 |--------|-------------|------|
 | 6 (mini) | 4*7=28 | Same as single |
-| 8 (normal) | 43-27=16 | Slightly better than 48-32=16 for pairs |
+| 8 (normal) | 43-27=16 | Slightly better than 48-32=16 for distinct pairs |
+
+**Quad Nerdle (quad space, len 8):**
+
+| First guess | Notes |
+|-------------|-------|
+| 1\*15-9=6 | Quad-optimal (stratified MC) |
+| 43-27=16 | Binerdle optimal; very close |
+| 48-32=16 | Single Nerdle optimal; very close |
+
+Run `./solve_quadnerdle data/equations_8.txt` to recompute. **All 4 equations are always distinct** (space = P(n,4) = n×(n-1)×(n-2)×(n-3), not n⁴). Uses **adaptive strategy** with stratified sampling and a 200k-quad tiebreaker when the top 2 are within 0.02 bits. Use `--no-stratify` for plain random sampling.
 
 **Benchmark stats (lengths 5–10):**
 
@@ -215,6 +258,28 @@ make clean        # remove binaries
 | 10 (maxi) | 3.65 | 0.2% | 37.6% | 59.0% | 3.2% |
 
 *Maxi stats from 5k-sample benchmark (`./bench_nerdle data/equations_10.txt --sample 5000`). Full benchmark ~1.8M equations would take hours.*
+
+---
+
+## Why different games favour different first guesses
+
+**Single Nerdle** maximizes H(fb) — how evenly the guess partitions the solution space. A guess like `48-32=16` is optimal because it creates many distinct feedback patterns with similar probability.
+
+**Binerdle** maximizes H(fb₁, fb₂) over *pairs* of equations. This equals H(fb₁) + H(fb₂|fb₁). A guess that’s good for single might induce correlated feedback when applied to two equations (similar equations → similar feedback). `43-27=16` is slightly better than `48-32=16` for pairs because it tends to produce more *independent* feedback across the two slots — knowing fb₁ gives less information about fb₂.
+
+**Quad Nerdle** maximizes H(fb₁, fb₂, fb₃, fb₄). We want each successive conditional entropy H(fbₖ|fb₁…fbₖ₋₁) to stay high. A guess that “spreads out” feedback across equations with different structure (operators, digits, result size) is better for Quad: it reduces correlation between the four patterns. A guess optimal for single might cluster too much feedback into a few joint patterns when applied to four diverse equations.
+
+---
+
+## Stratified sampling
+
+Plain Monte Carlo can undersample certain equation families (e.g. division-heavy or small-result equations). **Stratified sampling** classifies each equation by type (operator mix + result magnitude bucket) and samples proportionally from each stratum. This yields lower variance and a more stable ranking of guesses. Used in:
+
+- **solve_quadnerdle** — for finding the optimal first guess (use `--no-stratify` to disable)
+- **quadnerdle** — for subsequent guesses when the candidate space exceeds 50k
+- **binerdle** — for subsequent guesses when the pair space exceeds 50k
+
+Implementation uses 16 strata and proportional allocation.
 
 ---
 

--- a/src/bench_quadnerdle.cpp
+++ b/src/bench_quadnerdle.cpp
@@ -1,0 +1,298 @@
+/**
+ * Quad Nerdle benchmark - simulates solver over SAMPLED equation quadruples.
+ * Full enumeration (n^4) is infeasible, so we sample quadruples and report stats.
+ *
+ * Compile: g++ -O3 -std=c++17 -fopenmp -o bench_quadnerdle bench_quadnerdle.cpp
+ * Run:     ./bench_quadnerdle data/equations_8.txt
+ *          ./bench_quadnerdle data/equations_8.txt --sample 10000
+ */
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+constexpr int SEARCH_CAP = 400;
+constexpr size_t MC_QUAD_THRESHOLD = 50000;
+constexpr size_t MC_SAMPLE_SIZE = 12000;
+constexpr int MAX_TRIES = 10;
+constexpr size_t DEFAULT_BENCH_SAMPLES = 5000;
+
+std::string compute_feedback(const std::string& guess, const std::string& solution, int N) {
+    std::string result(N, 'B');
+    int sol_count[256] = {0};
+    for (char c : solution) sol_count[static_cast<unsigned char>(c)]++;
+
+    for (int i = 0; i < N; i++) {
+        if (guess[i] == solution[i]) {
+            result[i] = 'G';
+            sol_count[static_cast<unsigned char>(guess[i])]--;
+        }
+    }
+    for (int i = 0; i < N; i++) {
+        if (result[i] == 'G') continue;
+        char c = guess[i];
+        if (sol_count[static_cast<unsigned char>(c)] > 0) {
+            result[i] = 'P';
+            sol_count[static_cast<unsigned char>(c)]--;
+        }
+    }
+    return result;
+}
+
+bool is_consistent(const std::string& candidate, const std::string& guess,
+                   const std::string& feedback, int N) {
+    return compute_feedback(guess, candidate, N) == feedback;
+}
+
+/** Entropy of guess over QUAD space. Monte Carlo when huge. */
+double entropy_of_guess_quads(const std::string& guess,
+                             const std::vector<std::string>& all_eqs,
+                             const std::vector<size_t>& c1, const std::vector<size_t>& c2,
+                             const std::vector<size_t>& c3, const std::vector<size_t>& c4,
+                             int N) {
+    size_t n1 = c1.size(), n2 = c2.size(), n3 = c3.size(), n4 = c4.size();
+    size_t quad_count = n1 * n2 * n3 * n4;
+
+    std::unordered_map<std::string, int> pattern_count;
+
+    if (quad_count <= MC_QUAD_THRESHOLD) {
+        for (size_t ii : c1) {
+            std::string fb1 = compute_feedback(guess, all_eqs[ii], N);
+            for (size_t jj : c2) {
+                if (ii == jj) continue;
+                std::string fb2 = compute_feedback(guess, all_eqs[jj], N);
+                for (size_t kk : c3) {
+                    if (ii == kk || jj == kk) continue;
+                    std::string fb3 = compute_feedback(guess, all_eqs[kk], N);
+                    for (size_t ll : c4) {
+                        if (ii == ll || jj == ll || kk == ll) continue;
+                        std::string fb4 = compute_feedback(guess, all_eqs[ll], N);
+                        pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+                    }
+                }
+            }
+        }
+    } else {
+        size_t accepted = 0;
+        for (size_t s = 0; accepted < MC_SAMPLE_SIZE && s < MC_SAMPLE_SIZE * 5; s++) {
+            size_t r = s * 2654435761ULL;
+            size_t i = r % n1; r /= n1;
+            size_t j = r % n2; r /= n2;
+            size_t k = r % n3; r /= n3;
+            size_t l = r % n4;
+            size_t ei = c1[i], ej = c2[j], ek = c3[k], el = c4[l];
+            if (ei == ej || ei == ek || ei == el || ej == ek || ej == el || ek == el) continue;
+            std::string fb1 = compute_feedback(guess, all_eqs[ei], N);
+            std::string fb2 = compute_feedback(guess, all_eqs[ej], N);
+            std::string fb3 = compute_feedback(guess, all_eqs[ek], N);
+            std::string fb4 = compute_feedback(guess, all_eqs[el], N);
+            pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+            accepted++;
+        }
+    }
+
+    double total = 0;
+    for (const auto& kv : pattern_count) total += kv.second;
+    if (total <= 0) return 0.0;
+    double h = 0.0;
+    for (const auto& kv : pattern_count) {
+        double p = kv.second / total;
+        h -= p * std::log2(p);
+    }
+    return h;
+}
+
+std::string best_guess_quads(const std::vector<std::string>& all_eqs,
+                            const std::vector<size_t>& c1, const std::vector<size_t>& c2,
+                            const std::vector<size_t>& c3, const std::vector<size_t>& c4,
+                            int N) {
+    if (c1.size() == 1 && c2.size() == 1 && c3.size() == 1 && c4.size() == 1) {
+        return all_eqs[c1[0]];
+    }
+
+    std::unordered_set<size_t> union_set(c1.begin(), c1.end());
+    union_set.insert(c2.begin(), c2.end());
+    union_set.insert(c3.begin(), c3.end());
+    union_set.insert(c4.begin(), c4.end());
+
+    std::vector<size_t> pool_indices;
+    size_t n = all_eqs.size();
+    if (n <= (size_t)SEARCH_CAP) {
+        for (size_t i = 0; i < n; i++) pool_indices.push_back(i);
+    } else {
+        size_t step = n / SEARCH_CAP;
+        for (size_t i = 0; i < n && pool_indices.size() < (size_t)SEARCH_CAP; i += (step < 1 ? 1 : step))
+            pool_indices.push_back(i);
+    }
+
+    size_t best_idx = pool_indices[0];
+    double best_h = -1.0;
+    bool best_in_union = union_set.count(best_idx) > 0;
+    for (size_t idx : pool_indices) {
+        double h = entropy_of_guess_quads(all_eqs[idx], all_eqs, c1, c2, c3, c4, N);
+        bool in_union = union_set.count(idx) > 0;
+        if (h > best_h || (h == best_h && in_union && !best_in_union)) {
+            best_h = h;
+            best_idx = idx;
+            best_in_union = in_union;
+        }
+    }
+    return all_eqs[best_idx];
+}
+
+/** Solve Quad Nerdle for one quadruple. */
+int solve_quadnerdle_quad(size_t s1, size_t s2, size_t s3, size_t s4,
+                         const std::vector<std::string>& all_eqs,
+                         const std::string& first_guess, int N) {
+    std::vector<size_t> c1, c2, c3, c4;
+    for (size_t i = 0; i < all_eqs.size(); i++) {
+        c1.push_back(i);
+        c2.push_back(i);
+        c3.push_back(i);
+        c4.push_back(i);
+    }
+
+    std::string guess = first_guess;
+
+    for (int turn = 1; turn <= MAX_TRIES; turn++) {
+        std::string fb1 = compute_feedback(guess, all_eqs[s1], N);
+        std::string fb2 = compute_feedback(guess, all_eqs[s2], N);
+        std::string fb3 = compute_feedback(guess, all_eqs[s3], N);
+        std::string fb4 = compute_feedback(guess, all_eqs[s4], N);
+
+        std::vector<size_t> next_c1, next_c2, next_c3, next_c4;
+        for (size_t idx : c1) {
+            if (is_consistent(all_eqs[idx], guess, fb1, N)) next_c1.push_back(idx);
+        }
+        for (size_t idx : c2) {
+            if (is_consistent(all_eqs[idx], guess, fb2, N)) next_c2.push_back(idx);
+        }
+        for (size_t idx : c3) {
+            if (is_consistent(all_eqs[idx], guess, fb3, N)) next_c3.push_back(idx);
+        }
+        for (size_t idx : c4) {
+            if (is_consistent(all_eqs[idx], guess, fb4, N)) next_c4.push_back(idx);
+        }
+
+        c1 = std::move(next_c1);
+        c2 = std::move(next_c2);
+        c3 = std::move(next_c3);
+        c4 = std::move(next_c4);
+
+        if (c1.empty() || c2.empty() || c3.empty() || c4.empty()) {
+            return MAX_TRIES + 1;
+        }
+        if (c1.size() == 1 && c2.size() == 1 && c3.size() == 1 && c4.size() == 1) {
+            return turn;
+        }
+
+        guess = best_guess_quads(all_eqs, c1, c2, c3, c4, N);
+    }
+    return MAX_TRIES + 1;
+}
+
+int main(int argc, char** argv) {
+    size_t sample_count = DEFAULT_BENCH_SAMPLES;
+    std::string path = "data/equations_8.txt";
+    std::string first_guess_override;
+
+    for (int a = 1; a < argc; ) {
+        std::string arg = argv[a];
+        if (arg == "--sample" && a + 1 < argc) {
+            sample_count = static_cast<size_t>(std::atol(argv[a + 1]));
+            a += 2;
+        } else if (arg == "--single") {
+            first_guess_override = "48-32=16";
+            a++;
+        } else if (arg == "--binerdle") {
+            first_guess_override = "43-27=16";
+            a++;
+        } else if (arg[0] != '-') {
+            path = arg;
+            a++;
+        } else {
+            a++;
+        }
+    }
+
+    std::ifstream f(path);
+    if (!f) {
+        std::cerr << "Cannot open " << path << "\n";
+        return 1;
+    }
+
+    std::vector<std::string> equations;
+    std::string line;
+    while (std::getline(f, line)) {
+        if (!line.empty()) equations.push_back(line);
+    }
+    f.close();
+
+    if (equations.empty()) {
+        std::cerr << "No equations loaded.\n";
+        return 1;
+    }
+
+    int N = static_cast<int>(equations[0].size());
+    if (N != 8) {
+        std::cerr << "Quad Nerdle: use equations_8.txt\n";
+        return 1;
+    }
+
+    std::string first_guess = first_guess_override.empty() ? "43-27=16" : first_guess_override;
+    size_t n = equations.size();
+
+    std::cout << "Quad Nerdle benchmark (" << n << " equations, "
+              << sample_count << " sampled quadruples";
+    if (!first_guess_override.empty()) {
+        std::cout << ", first guess: " << first_guess;
+    }
+    std::cout << ")\n\n";
+
+    std::vector<int> turn_dist(MAX_TRIES + 3, 0);
+    double sum_turns = 0;
+
+    /* Generate sample indices: DISTINCT quadruples (i,j,k,l) - all 4 equations different */
+    std::vector<std::array<size_t,4>> samples;
+    samples.reserve(sample_count);
+    for (size_t t = 0; samples.size() < sample_count && t < sample_count * 5; t++) {
+        size_t r = (t * 2654435761ULL);
+        size_t i = (r) % n; r /= n;
+        size_t j = (r) % n; r /= n;
+        size_t k = (r) % n; r /= n;
+        size_t l = (r) % n;
+        if (i != j && i != k && i != l && j != k && j != l && k != l) {
+            samples.push_back({i, j, k, l});
+        }
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic, 4) reduction(+:sum_turns)
+#endif
+    for (size_t t = 0; t < samples.size(); t++) {
+        size_t i = samples[t][0], j = samples[t][1], k = samples[t][2], l = samples[t][3];
+        int turns = solve_quadnerdle_quad(i, j, k, l, equations, first_guess, N);
+        sum_turns += turns;
+#ifdef _OPENMP
+#pragma omp critical
+#endif
+        turn_dist[turns]++;
+    }
+
+    size_t num_samples = samples.size();
+    std::cout << "Quad Nerdle (one guess for all 4, 10 tries, distinct quads):\n";
+    std::cout << "  Mean guesses: " << (num_samples > 0 ? sum_turns / num_samples : 0) << "\n";
+    std::cout << "  Distribution: ";
+    for (int k = 1; k <= MAX_TRIES + 1; k++) {
+        if (turn_dist[k] > 0) std::cout << k << ":" << turn_dist[k] << " ";
+    }
+    std::cout << "\n";
+    std::cout << "  Failures (11+): " << turn_dist[MAX_TRIES + 1] << "\n";
+
+    return 0;
+}

--- a/src/binerdle.cpp
+++ b/src/binerdle.cpp
@@ -18,6 +18,7 @@
 constexpr int SEARCH_CAP = 600;  /* No subsample of union when |c1∪c2| <= this */
 constexpr size_t MC_PAIR_THRESHOLD = 50000;  /* Use Monte Carlo above this */
 constexpr size_t MC_SAMPLE_SIZE = 8000;
+static const int NUM_STRATA = 16;
 constexpr int MAX_TRIES = 7;
 
 static const std::unordered_map<int, std::string> FIRST_GUESS = {
@@ -52,7 +53,25 @@ bool is_consistent(const std::string& candidate, const std::string& guess,
     return compute_feedback(guess, candidate, N) == feedback;
 }
 
-/** Entropy of guess over PAIR space (c1 x c2). Uses Monte Carlo when too large. */
+int equation_type(const std::string& eq) {
+    size_t eq_pos = eq.find('=');
+    if (eq_pos == std::string::npos) return 0;
+    long long rhs = 0;
+    for (size_t i = eq_pos + 1; i < eq.size(); i++) {
+        if (eq[i] >= '0' && eq[i] <= '9') rhs = rhs * 10 + (eq[i] - '0');
+    }
+    int op_mask = 0;
+    for (size_t i = 0; i < eq_pos; i++) {
+        if (eq[i] == '+') op_mask |= 1;
+        else if (eq[i] == '-') op_mask |= 2;
+        else if (eq[i] == '*') op_mask |= 4;
+        else if (eq[i] == '/') op_mask |= 8;
+    }
+    int result_bucket = (rhs <= 9) ? 0 : (rhs <= 99) ? 1 : 2;
+    return (op_mask % 8) * 3 + result_bucket;
+}
+
+/** Entropy of guess over PAIR space (c1 x c2), distinct pairs. Uses stratified MC when too large. */
 double entropy_of_guess_pairs(const std::string& guess,
                               const std::vector<std::string>& all_eqs,
                               const std::vector<size_t>& c1, const std::vector<size_t>& c2,
@@ -61,22 +80,52 @@ double entropy_of_guess_pairs(const std::string& guess,
     std::unordered_map<std::string, int> pattern_count;
 
     if (pair_count <= MC_PAIR_THRESHOLD) {
-        for (size_t i : c1) {
-            std::string fb1 = compute_feedback(guess, all_eqs[i], N);
-            for (size_t j : c2) {
-                std::string fb2 = compute_feedback(guess, all_eqs[j], N);
+        for (size_t ii : c1) {
+            std::string fb1 = compute_feedback(guess, all_eqs[ii], N);
+            for (size_t jj : c2) {
+                if (ii == jj) continue;  /* distinct pairs */
+                std::string fb2 = compute_feedback(guess, all_eqs[jj], N);
                 pattern_count[fb1 + "|" + fb2]++;
             }
         }
     } else {
-        /* Monte Carlo: deterministic strided sample */
-        size_t step = pair_count / MC_SAMPLE_SIZE;
-        if (step < 1) step = 1;
-        for (size_t ij = 0; ij < pair_count; ij += step) {
-            size_t i = ij % c1.size(), j = ij / c1.size();
-            std::string fb1 = compute_feedback(guess, all_eqs[c1[i]], N);
-            std::string fb2 = compute_feedback(guess, all_eqs[c2[j]], N);
+        /* Stratified MC: partition c1 by equation type, sample proportionally, distinct */
+        std::vector<std::vector<size_t>> strata(NUM_STRATA);
+        for (size_t idx : c1) {
+            int t = equation_type(all_eqs[idx]) % NUM_STRATA;
+            strata[t].push_back(idx);
+        }
+        size_t n1 = c1.size(), n2 = c2.size();
+        size_t accepted = 0;
+        for (int h = 0; h < NUM_STRATA && accepted < MC_SAMPLE_SIZE; h++) {
+            if (strata[h].empty()) continue;
+            size_t n_h = (MC_SAMPLE_SIZE * strata[h].size() + n1 - 1) / n1;
+            if (n_h == 0) n_h = 1;
+            for (size_t sh = 0; sh < n_h && accepted < MC_SAMPLE_SIZE; sh++) {
+                size_t r = (h * 7919ULL + sh * 2654435761ULL);
+                size_t ei = strata[h][r % strata[h].size()];
+                for (int attempt = 0; attempt < 20; attempt++) {
+                    r = r * 7919 + 2654435761;
+                    size_t j = r % n2;
+                    size_t ej = c2[j];
+                    if (ei == ej) continue;
+                    std::string fb1 = compute_feedback(guess, all_eqs[ei], N);
+                    std::string fb2 = compute_feedback(guess, all_eqs[ej], N);
+                    pattern_count[fb1 + "|" + fb2]++;
+                    accepted++;
+                    break;
+                }
+            }
+        }
+        for (size_t s = accepted; accepted < MC_SAMPLE_SIZE && s < MC_SAMPLE_SIZE * 5; s++) {
+            size_t r = s * 2654435761ULL;
+            size_t i = r % n1, j = (r / n1) % n2;
+            size_t ei = c1[i], ej = c2[j];
+            if (ei == ej) continue;
+            std::string fb1 = compute_feedback(guess, all_eqs[ei], N);
+            std::string fb2 = compute_feedback(guess, all_eqs[ej], N);
             pattern_count[fb1 + "|" + fb2]++;
+            accepted++;
         }
     }
 

--- a/src/quadnerdle.cpp
+++ b/src/quadnerdle.cpp
@@ -1,0 +1,360 @@
+/**
+ * Quad Nerdle solver - guess 4 Nerdles in 10 tries.
+ * Supports len 8 (classic). Same principle as Binerdle but 4 games at once.
+ *
+ * Compile: g++ -O3 -std=c++17 -fopenmp -o quadnerdle quadnerdle.cpp
+ * Run:     ./quadnerdle --len 8
+ */
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+constexpr int SEARCH_CAP = 400;   /* Smaller pool for quad (entropy heavier) */
+constexpr size_t MC_QUAD_THRESHOLD = 50000;  /* Always MC above this */
+constexpr size_t MC_SAMPLE_SIZE = 12000;     /* Sample size for quad entropy */
+static const int NUM_STRATA = 16;
+constexpr int MAX_TRIES = 10;
+
+static const std::unordered_map<int, std::string> FIRST_GUESS = {
+    {8, "43-27=16"},  /* Start with Binerdle optimal; run solve_quadnerdle for true optimal */
+};
+
+std::string compute_feedback(const std::string& guess, const std::string& solution, int N) {
+    std::string result(N, 'B');
+    int remaining[256] = {0};
+    for (char c : solution) remaining[static_cast<unsigned char>(c)]++;
+    for (int i = 0; i < N; i++) {
+        if (guess[i] == solution[i]) {
+            result[i] = 'G';
+            remaining[static_cast<unsigned char>(guess[i])]--;
+        }
+    }
+    for (int i = 0; i < N; i++) {
+        if (result[i] == 'G') continue;
+        unsigned char c = static_cast<unsigned char>(guess[i]);
+        if (remaining[c] > 0) {
+            result[i] = 'P';
+            remaining[c]--;
+        }
+    }
+    return result;
+}
+
+bool is_consistent(const std::string& candidate, const std::string& guess,
+                   const std::string& feedback, int N) {
+    return compute_feedback(guess, candidate, N) == feedback;
+}
+
+int equation_type(const std::string& eq) {
+    size_t eq_pos = eq.find('=');
+    if (eq_pos == std::string::npos) return 0;
+    long long rhs = 0;
+    for (size_t i = eq_pos + 1; i < eq.size(); i++) {
+        if (eq[i] >= '0' && eq[i] <= '9') rhs = rhs * 10 + (eq[i] - '0');
+    }
+    int op_mask = 0;
+    for (size_t i = 0; i < eq_pos; i++) {
+        if (eq[i] == '+') op_mask |= 1;
+        else if (eq[i] == '-') op_mask |= 2;
+        else if (eq[i] == '*') op_mask |= 4;
+        else if (eq[i] == '/') op_mask |= 8;
+    }
+    int result_bucket = (rhs <= 9) ? 0 : (rhs <= 99) ? 1 : 2;
+    return (op_mask % 8) * 3 + result_bucket;
+}
+
+/** Entropy of guess over QUAD space (c1 x c2 x c3 x c4). Uses Monte Carlo when huge.
+    When using MC, stratifies by equation type of first slot for lower variance. */
+double entropy_of_guess_quads(const std::string& guess,
+                              const std::vector<std::string>& all_eqs,
+                              const std::vector<size_t>& c1, const std::vector<size_t>& c2,
+                              const std::vector<size_t>& c3, const std::vector<size_t>& c4,
+                              int N) {
+    size_t n1 = c1.size(), n2 = c2.size(), n3 = c3.size(), n4 = c4.size();
+    size_t quad_count = n1;
+    if (quad_count > 0) quad_count *= n2;
+    if (quad_count > 0 && n2 > 0) quad_count *= n3;
+    if (quad_count > 0 && n3 > 0) quad_count *= n4;
+
+    std::unordered_map<std::string, int> pattern_count;
+
+    if (quad_count <= MC_QUAD_THRESHOLD && n2 > 0 && n3 > 0 && n4 > 0) {
+        for (size_t ii : c1) {
+            std::string fb1 = compute_feedback(guess, all_eqs[ii], N);
+            for (size_t jj : c2) {
+                if (ii == jj) continue;
+                std::string fb2 = compute_feedback(guess, all_eqs[jj], N);
+                for (size_t kk : c3) {
+                    if (ii == kk || jj == kk) continue;
+                    std::string fb3 = compute_feedback(guess, all_eqs[kk], N);
+                    for (size_t ll : c4) {
+                        if (ii == ll || jj == ll || kk == ll) continue;
+                        std::string fb4 = compute_feedback(guess, all_eqs[ll], N);
+                        pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+                    }
+                }
+            }
+        }
+    } else {
+        /* Stratified MC: partition c1 by equation type, sample proportionally */
+        std::vector<std::vector<size_t>> strata(NUM_STRATA);
+        for (size_t idx : c1) {
+            int t = equation_type(all_eqs[idx]) % NUM_STRATA;
+            strata[t].push_back(idx);
+        }
+        size_t accepted = 0;
+        for (int h = 0; h < NUM_STRATA && accepted < MC_SAMPLE_SIZE; h++) {
+            if (strata[h].empty()) continue;
+            size_t n_h = (MC_SAMPLE_SIZE * strata[h].size() + n1 - 1) / n1;
+            if (n_h == 0) n_h = 1;
+            for (size_t sh = 0; sh < n_h && accepted < MC_SAMPLE_SIZE; sh++) {
+                size_t r = (h * 7919ULL + sh * 2654435761ULL);
+                size_t ei = strata[h][r % strata[h].size()];
+                for (int attempt = 0; attempt < 30; attempt++) {
+                    r = r * 7919 + 2654435761;
+                    size_t j = r % n2; r /= n2;
+                    size_t k = r % n3; r /= n3;
+                    size_t l = r % n4;
+                    size_t ej = c2[j], ek = c3[k], el = c4[l];
+                    if (ei == ej || ei == ek || ei == el || ej == ek || ej == el || ek == el) continue;
+                    std::string fb1 = compute_feedback(guess, all_eqs[ei], N);
+                    std::string fb2 = compute_feedback(guess, all_eqs[ej], N);
+                    std::string fb3 = compute_feedback(guess, all_eqs[ek], N);
+                    std::string fb4 = compute_feedback(guess, all_eqs[el], N);
+                    pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+                    accepted++;
+                    break;
+                }
+            }
+        }
+        /* Fill remainder with plain rejection */
+        for (size_t s = 0; accepted < MC_SAMPLE_SIZE && s < MC_SAMPLE_SIZE * 5; s++) {
+            size_t r = s * 2654435761ULL;
+            size_t i = r % n1; r /= n1;
+            size_t j = r % n2; r /= n2;
+            size_t k = r % n3; r /= n3;
+            size_t l = r % n4;
+            size_t ei = c1[i], ej = c2[j], ek = c3[k], el = c4[l];
+            if (ei == ej || ei == ek || ei == el || ej == ek || ej == el || ek == el) continue;
+            std::string fb1 = compute_feedback(guess, all_eqs[ei], N);
+            std::string fb2 = compute_feedback(guess, all_eqs[ej], N);
+            std::string fb3 = compute_feedback(guess, all_eqs[ek], N);
+            std::string fb4 = compute_feedback(guess, all_eqs[el], N);
+            pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+            accepted++;
+        }
+    }
+
+    double total = 0;
+    for (const auto& kv : pattern_count) total += kv.second;
+    if (total <= 0) return 0.0;
+    double h = 0.0;
+    for (const auto& kv : pattern_count) {
+        double p = kv.second / total;
+        h -= p * std::log2(p);
+    }
+    return h;
+}
+
+/** Best guess that maximizes entropy over quad space. */
+std::string best_guess_quads(const std::vector<std::string>& all_eqs,
+                            const std::vector<size_t>& c1, const std::vector<size_t>& c2,
+                            const std::vector<size_t>& c3, const std::vector<size_t>& c4,
+                            int N, bool solved[4]) {
+    int num_identified = (c1.size() == 1 ? 1 : 0) + (c2.size() == 1 ? 1 : 0)
+                      + (c3.size() == 1 ? 1 : 0) + (c4.size() == 1 ? 1 : 0);
+
+    if (num_identified == 4) {
+        /* All identified: guess one we haven't solved */
+        if (!solved[0]) return all_eqs[c1[0]];
+        if (!solved[1]) return all_eqs[c2[0]];
+        if (!solved[2]) return all_eqs[c3[0]];
+        return all_eqs[c4[0]];
+    }
+
+    /* When one slot is identified, prefer guessing it if entropy > 0 */
+    if (c1.size() == 1 && c2.size() > 1) {
+        double h = entropy_of_guess_quads(all_eqs[c1[0]], all_eqs, c1, c2, c3, c4, N);
+        if (h > 0) return all_eqs[c1[0]];
+    }
+    if (c2.size() == 1 && (c1.size() > 1 || c3.size() > 1 || c4.size() > 1)) {
+        double h = entropy_of_guess_quads(all_eqs[c2[0]], all_eqs, c1, c2, c3, c4, N);
+        if (h > 0) return all_eqs[c2[0]];
+    }
+    if (c3.size() == 1 && (c1.size() > 1 || c2.size() > 1 || c4.size() > 1)) {
+        double h = entropy_of_guess_quads(all_eqs[c3[0]], all_eqs, c1, c2, c3, c4, N);
+        if (h > 0) return all_eqs[c3[0]];
+    }
+    if (c4.size() == 1 && (c1.size() > 1 || c2.size() > 1 || c3.size() > 1)) {
+        double h = entropy_of_guess_quads(all_eqs[c4[0]], all_eqs, c1, c2, c3, c4, N);
+        if (h > 0) return all_eqs[c4[0]];
+    }
+
+    std::unordered_set<size_t> union_set(c1.begin(), c1.end());
+    union_set.insert(c2.begin(), c2.end());
+    union_set.insert(c3.begin(), c3.end());
+    union_set.insert(c4.begin(), c4.end());
+
+    std::vector<size_t> pool_indices;
+    size_t n = all_eqs.size();
+    if (n <= (size_t)SEARCH_CAP) {
+        for (size_t i = 0; i < n; i++) pool_indices.push_back(i);
+    } else {
+        size_t step = n / SEARCH_CAP;
+        for (size_t i = 0; i < n && pool_indices.size() < (size_t)SEARCH_CAP; i += (step < 1 ? 1 : step))
+            pool_indices.push_back(i);
+    }
+
+    size_t best_idx = pool_indices[0];
+    double best_h = -1.0;
+    bool best_in_union = union_set.count(best_idx) > 0;
+    for (size_t idx : pool_indices) {
+        double h = entropy_of_guess_quads(all_eqs[idx], all_eqs, c1, c2, c3, c4, N);
+        bool in_union = union_set.count(idx) > 0;
+        if (h > best_h || (h == best_h && in_union && !best_in_union)) {
+            best_h = h;
+            best_idx = idx;
+            best_in_union = in_union;
+        }
+    }
+    return all_eqs[best_idx];
+}
+
+void filter_candidates(const std::vector<std::string>& all_eqs,
+                      const std::vector<size_t>& in,
+                      const std::string& guess, const std::string& feedback,
+                      int N, std::vector<size_t>& out) {
+    out.clear();
+    for (size_t idx : in) {
+        if (is_consistent(all_eqs[idx], guess, feedback, N)) {
+            out.push_back(idx);
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    int N = 8;
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "--len" && i + 1 < argc) {
+            N = std::atoi(argv[++i]);
+        }
+    }
+
+    if (N != 8) {
+        std::cerr << "Quad Nerdle: use --len 8 (classic)\n";
+        return 1;
+    }
+
+    std::string path = "data/equations_" + std::to_string(N) + ".txt";
+    std::ifstream f(path);
+    if (!f) {
+        std::cerr << "Cannot open " << path << ". Run ./generate --len " << N << " first.\n";
+        return 1;
+    }
+
+    std::vector<std::string> equations;
+    std::string line;
+    while (std::getline(f, line)) {
+        if (!line.empty()) equations.push_back(line);
+    }
+    f.close();
+
+    std::cout << "\n╔═══════════════════════════════╗\n";
+    std::cout << "║   Q U A D   N E R D L E       ║\n";
+    std::cout << "║   4 equations · 10 tries      ║\n";
+    std::cout << "╚═══════════════════════════════╝\n";
+    std::cout << "Feedback: G=Green  P=Purple  B=Black\n";
+    std::cout << "Loaded " << equations.size() << " equations.\n\n";
+
+    std::vector<size_t> c1, c2, c3, c4;
+    for (size_t i = 0; i < equations.size(); i++) {
+        c1.push_back(i);
+        c2.push_back(i);
+        c3.push_back(i);
+        c4.push_back(i);
+    }
+
+    std::string guess = FIRST_GUESS.at(N);
+    bool solved[4] = {false, false, false, false};
+
+    for (int turn = 1; turn <= MAX_TRIES; turn++) {
+        std::cout << "Guess " << turn << "/" << MAX_TRIES << "\n";
+        std::cout << "  Eq 1: " << (solved[0] ? "✓" : std::to_string(c1.size()) + " candidates")
+                  << " | Eq 2: " << (solved[1] ? "✓" : std::to_string(c2.size()) + " candidates")
+                  << " | Eq 3: " << (solved[2] ? "✓" : std::to_string(c3.size()) + " candidates")
+                  << " | Eq 4: " << (solved[3] ? "✓" : std::to_string(c4.size()) + " candidates")
+                  << "\n";
+        std::cout << "  Suggested: " << guess << "\n";
+        std::cout << "  Your guess (Enter=suggested): ";
+        std::string user_guess;
+        std::getline(std::cin, user_guess);
+        if (user_guess == "q" || user_guess == "quit") return 0;
+        if (!user_guess.empty() && (int)user_guess.size() == N) {
+            guess = user_guess;
+        }
+        std::cout << "  Using: " << guess << "\n\n";
+
+        std::string f1, f2, f3, f4;
+
+        auto read_feedback = [&](int eq_num, bool is_solved, std::vector<size_t>& cand) {
+            if (is_solved) {
+                return compute_feedback(guess, equations[cand[0]], N);
+            }
+            std::cout << "  Feedback eq " << eq_num << " (" << N << " chars G/P/B, or 'y' if correct): ";
+            std::string fb;
+            std::getline(std::cin, fb);
+            if (fb == "q" || fb == "quit") exit(0);
+            if (fb == "y" || fb == "Y") fb = std::string(N, 'G');
+            while ((int)fb.size() != N) {
+                std::cout << "  Enter " << N << " characters: ";
+                std::getline(std::cin, fb);
+            }
+            for (char& c : fb) c = (char)std::toupper(c);
+            return fb;
+        };
+
+        f1 = read_feedback(1, solved[0], c1);
+        f2 = read_feedback(2, solved[1], c2);
+        f3 = read_feedback(3, solved[2], c3);
+        f4 = read_feedback(4, solved[3], c4);
+
+        /* Never overwrite solved: once an eq is solved, it stays solved */
+        if (!solved[0]) solved[0] = (f1 == std::string(N, 'G'));
+        if (!solved[1]) solved[1] = (f2 == std::string(N, 'G'));
+        if (!solved[2]) solved[2] = (f3 == std::string(N, 'G'));
+        if (!solved[3]) solved[3] = (f4 == std::string(N, 'G'));
+
+        if (solved[0] && solved[1] && solved[2] && solved[3]) {
+            std::cout << "\n✓ Solved in " << turn << " guess(es)!\n";
+            return 0;
+        }
+
+        std::vector<size_t> next_c1, next_c2, next_c3, next_c4;
+        filter_candidates(equations, c1, guess, f1, N, next_c1);
+        filter_candidates(equations, c2, guess, f2, N, next_c2);
+        filter_candidates(equations, c3, guess, f3, N, next_c3);
+        filter_candidates(equations, c4, guess, f4, N, next_c4);
+
+        c1 = std::move(next_c1);
+        c2 = std::move(next_c2);
+        c3 = std::move(next_c3);
+        c4 = std::move(next_c4);
+
+        if (c1.empty() || c2.empty() || c3.empty() || c4.empty()) {
+            std::cout << "\nNo candidates remain. Check your feedback.\n";
+            return 1;
+        }
+
+        guess = best_guess_quads(equations, c1, c2, c3, c4, N, solved);
+        std::cout << "\n";
+    }
+
+    std::cout << "Out of guesses.\n";
+    return 0;
+}

--- a/src/solve_quadnerdle.cpp
+++ b/src/solve_quadnerdle.cpp
@@ -1,0 +1,373 @@
+/**
+ * Quad Nerdle optimal first guess - maximizes entropy over DISTINCT quad space.
+ * All 4 equations are always distinct: space is P(n,4) = n*(n-1)*(n-2)*(n-3).
+ * Uses adaptive strategy: prune via confidence intervals, then more MC trials for finalists.
+ *
+ * Run: ./solve_quadnerdle data/equations_8.txt
+ */
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+constexpr size_t PHASE1_SAMPLES = 5000;   /* Phase 1: small sample, all candidates */
+constexpr size_t PHASE2_SAMPLES = 25000;  /* Phase 2: larger sample, survivors */
+constexpr size_t PHASE3_SAMPLES = 50000;  /* Phase 3: final round, top ~50 by Phase 2 */
+constexpr size_t PHASE3_TOP = 50;         /* Max finalists for Phase 3 (avoids 5k*50k) */
+constexpr size_t TIEBREAKER_SAMPLES = 200000;  /* Extra samples if top 2 within epsilon */
+constexpr double TIE_EPSILON = 0.02;       /* Bits; run tiebreaker if |h1-h2| < this */
+constexpr double Z = 3.291;  /* ~99.9% confidence interval */
+
+std::string compute_feedback(const std::string& guess, const std::string& solution, int N) {
+    std::string result(N, 'B');
+    int sol_count[256] = {0};
+    for (char c : solution) sol_count[static_cast<unsigned char>(c)]++;
+
+    for (int i = 0; i < N; i++) {
+        if (guess[i] == solution[i]) {
+            result[i] = 'G';
+            sol_count[static_cast<unsigned char>(guess[i])]--;
+        }
+    }
+    for (int i = 0; i < N; i++) {
+        if (result[i] == 'G') continue;
+        char c = guess[i];
+        if (sol_count[static_cast<unsigned char>(c)] > 0) {
+            result[i] = 'P';
+            sol_count[static_cast<unsigned char>(c)]--;
+        }
+    }
+    return result;
+}
+
+/* Compute entropy and its variance over a fixed sample of distinct quads. */
+void entropy_and_var_distinct(const std::string& guess,
+                              const std::vector<std::string>& all_eqs,
+                              const std::vector<std::array<size_t,4>>& quads,
+                              int N, double& out_h, double& out_var) {
+    std::unordered_map<std::string, int> pattern_count;
+    for (const auto& q : quads) {
+        std::string fb1 = compute_feedback(guess, all_eqs[q[0]], N);
+        std::string fb2 = compute_feedback(guess, all_eqs[q[1]], N);
+        std::string fb3 = compute_feedback(guess, all_eqs[q[2]], N);
+        std::string fb4 = compute_feedback(guess, all_eqs[q[3]], N);
+        pattern_count[fb1 + "|" + fb2 + "|" + fb3 + "|" + fb4]++;
+    }
+    double n = static_cast<double>(quads.size());
+    if (n <= 1) { out_h = 0; out_var = 0; return; }
+    double h = 0.0, sum_log_sq = 0.0;
+    for (const auto& kv : pattern_count) {
+        double p = kv.second / n;
+        if (p > 0) {
+            double lp = std::log2(p);
+            h -= p * lp;
+            sum_log_sq += p * lp * lp;
+        }
+    }
+    out_h = h;
+    out_var = (sum_log_sq - h * h) / n;
+    if (out_var < 0) out_var = 0;
+}
+
+/* Classify equation for stratification: type = f(operators, result magnitude).
+   Returns 0..NUM_STRATA-1. Reduces variance by ensuring coverage across equation "families". */
+static const int NUM_STRATA = 16;
+int equation_type(const std::string& eq) {
+    size_t eq_pos = eq.find('=');
+    if (eq_pos == std::string::npos) return 0;
+    long long rhs = 0;
+    for (size_t i = eq_pos + 1; i < eq.size(); i++) {
+        if (eq[i] >= '0' && eq[i] <= '9')
+            rhs = rhs * 10 + (eq[i] - '0');
+    }
+    int op_mask = 0;  /* bits: + -, * / */
+    for (size_t i = 0; i < eq_pos; i++) {
+        if (eq[i] == '+') op_mask |= 1;
+        else if (eq[i] == '-') op_mask |= 2;
+        else if (eq[i] == '*') op_mask |= 4;
+        else if (eq[i] == '/') op_mask |= 8;
+    }
+    int result_bucket = (rhs <= 9) ? 0 : (rhs <= 99) ? 1 : 2;
+    int type = (op_mask % 8) * 3 + result_bucket;  /* 0..23, wrap to 0..15 */
+    return type % NUM_STRATA;
+}
+
+/* Proportional stratified sampling: partition by first equation's type.
+   N_h = |strata_h| * P(n-1,3), so n_h ∝ |strata_h|. Sample n_h from stratum h. */
+std::vector<std::array<size_t,4>> sample_distinct_quads_stratified(
+    const std::vector<std::string>& equations, size_t target) {
+    size_t n = equations.size();
+    if (n < 4) return {};
+    std::vector<std::vector<size_t>> strata(NUM_STRATA);
+    for (size_t i = 0; i < n; i++) {
+        int t = equation_type(equations[i]);
+        strata[t].push_back(i);
+    }
+    std::vector<std::array<size_t,4>> quads;
+    quads.reserve(target);
+    for (int h = 0; h < NUM_STRATA; h++) {
+        if (strata[h].empty()) continue;
+        size_t n_h = (target * strata[h].size() + n/2) / n;
+        if (n_h == 0) n_h = 1;
+        for (size_t sh = 0; sh < n_h && quads.size() < target; sh++) {
+            size_t r = (h * 7919ULL + sh * 2654435761ULL);
+            size_t i = strata[h][r % strata[h].size()];
+            /* Pick j,k,l distinct and != i via rejection */
+            for (int attempt = 0; attempt < 50; attempt++) {
+                r = r * 7919 + 2654435761;
+                size_t j = r % n; r /= n;
+                size_t k = r % n; r /= n;
+                size_t l = r % n;
+                if (j != i && k != i && l != i && j != k && j != l && k != l) {
+                    quads.push_back({i, j, k, l});
+                    break;
+                }
+            }
+        }
+    }
+    /* Fill remainder with plain rejection if we're short */
+    while (quads.size() < target) {
+        size_t s = quads.size() * 2654435761ULL;
+        size_t i = (s) % n; s /= n;
+        size_t j = (s) % n; s /= n;
+        size_t k = (s) % n; s /= n;
+        size_t l = (s) % n;
+        if (i != j && i != k && i != l && j != k && j != l && k != l)
+            quads.push_back({i, j, k, l});
+    }
+    return quads;
+}
+
+/* Fallback: plain rejection sampling. */
+std::vector<std::array<size_t,4>> sample_distinct_quads(size_t n, size_t target) {
+    std::vector<std::array<size_t,4>> quads;
+    quads.reserve(target);
+    for (size_t s = 0; quads.size() < target && s < target * 5; s++) {
+        size_t r = (s * 2654435761ULL);
+        size_t i = (r) % n; r /= n;
+        size_t j = (r) % n; r /= n;
+        size_t k = (r) % n; r /= n;
+        size_t l = (r) % n;
+        if (i != j && i != k && i != l && j != k && j != l && k != l) {
+            quads.push_back({i, j, k, l});
+        }
+    }
+    return quads;
+}
+
+int main(int argc, char** argv) {
+    std::string path = "data/equations_8.txt";
+    bool use_stratification = true;
+    for (int a = 1; a < argc; a++) {
+        std::string arg = argv[a];
+        if (arg == "--no-stratify") use_stratification = false;
+        else if (arg[0] != '-') path = arg;
+    }
+
+    std::ifstream f(path);
+    if (!f) {
+        std::cerr << "Cannot open " << path << "\n";
+        return 1;
+    }
+
+    std::vector<std::string> equations;
+    std::string line;
+    while (std::getline(f, line)) {
+        if (!line.empty()) equations.push_back(line);
+    }
+    f.close();
+
+    if (equations.empty()) {
+        std::cerr << "No equations loaded.\n";
+        return 1;
+    }
+
+    int N = static_cast<int>(equations[0].size());
+    if (N != 8) {
+        std::cerr << "Quad Nerdle: use equations_8.txt\n";
+        return 1;
+    }
+
+    size_t n = equations.size();
+    size_t P4 = (n >= 4) ? (n * (n-1) * (n-2) * (n-3)) : 0;
+
+    std::cout << "Quad Nerdle optimal first guess (" << n << " equations, "
+              << P4 << " distinct quadruples, adaptive MC"
+              << (use_stratification ? ", stratified" : "") << ")\n\n";
+
+    /* Benchmark first guesses */
+    std::string single_first = "48-32=16";
+    std::string binerdle_first = "43-27=16";
+
+    /* Phase 1: distinct quads (stratified by equation type for lower variance), evaluate ALL */
+    std::cerr << "Phase 1: " << PHASE1_SAMPLES << " quads, all " << n << " candidates... " << std::flush;
+    std::vector<std::array<size_t,4>> quads1 = use_stratification
+        ? sample_distinct_quads_stratified(equations, PHASE1_SAMPLES)
+        : sample_distinct_quads(n, PHASE1_SAMPLES);
+    if (quads1.size() < PHASE1_SAMPLES / 2) {
+        std::cerr << "Warning: only got " << quads1.size() << " distinct quads\n";
+    }
+
+    std::vector<std::pair<double, double>> h_var(n);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic, 8)
+#endif
+    for (size_t c = 0; c < n; c++) {
+        entropy_and_var_distinct(equations[c], equations, quads1, N, h_var[c].first, h_var[c].second);
+    }
+
+    double best_h = -1;
+    for (size_t c = 0; c < n; c++) {
+        if (h_var[c].first > best_h) best_h = h_var[c].first;
+    }
+    double best_se = 0;
+    for (size_t c = 0; c < n; c++) {
+        if (h_var[c].first == best_h) {
+            best_se = std::sqrt(h_var[c].second);
+            break;
+        }
+    }
+    double cutoff = best_h - Z * best_se;
+
+    std::vector<size_t> survivors;
+    for (size_t c = 0; c < n; c++) {
+        double ub = h_var[c].first + Z * std::sqrt(h_var[c].second);
+        if (ub >= cutoff) survivors.push_back(c);
+    }
+    std::cerr << "→ " << survivors.size() << " survivors\n";
+
+    /* Add benchmark guesses to survivors if not already */
+    size_t single_idx = n, binerdle_idx = n;
+    for (size_t i = 0; i < n; i++) {
+        if (equations[i] == single_first) single_idx = i;
+        if (equations[i] == binerdle_first) binerdle_idx = i;
+    }
+    if (single_idx < n) {
+        auto it = std::find(survivors.begin(), survivors.end(), single_idx);
+        if (it == survivors.end()) survivors.push_back(single_idx);
+    }
+    if (binerdle_idx < n) {
+        auto it = std::find(survivors.begin(), survivors.end(), binerdle_idx);
+        if (it == survivors.end()) survivors.push_back(binerdle_idx);
+    }
+
+    if (survivors.size() <= 1) {
+        std::string best_eq = equations[survivors[0]];
+        std::cout << "Quad Nerdle-optimal first guess: " << best_eq << "\n";
+        return 0;
+    }
+
+    /* Phase 2: larger sample, survivors only */
+    std::cerr << "Phase 2: " << PHASE2_SAMPLES << " quads, " << survivors.size() << " survivors... " << std::flush;
+    std::vector<std::array<size_t,4>> quads2 = use_stratification
+        ? sample_distinct_quads_stratified(equations, PHASE2_SAMPLES)
+        : sample_distinct_quads(n, PHASE2_SAMPLES);
+
+    std::vector<std::pair<double, double>> h_var2(survivors.size());
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic, 8)
+#endif
+    for (size_t s = 0; s < survivors.size(); s++) {
+        size_t c = survivors[s];
+        entropy_and_var_distinct(equations[c], equations, quads2, N, h_var2[s].first, h_var2[s].second);
+    }
+
+    best_h = -1;
+    for (size_t s = 0; s < survivors.size(); s++) {
+        if (h_var2[s].first > best_h) best_h = h_var2[s].first;
+    }
+    best_se = 0;
+    for (size_t s = 0; s < survivors.size(); s++) {
+        if (h_var2[s].first == best_h) {
+            best_se = std::sqrt(h_var2[s].second);
+            break;
+        }
+    }
+    cutoff = best_h - Z * best_se;
+
+    std::vector<size_t> finalists;
+    for (size_t s = 0; s < survivors.size(); s++) {
+        double ub = h_var2[s].first + Z * std::sqrt(h_var2[s].second);
+        if (ub >= cutoff) finalists.push_back(survivors[s]);
+    }
+    /* Trim to top PHASE3_TOP by point estimate for Phase 3 (avoid 5k*50k evals) */
+    if (finalists.size() > PHASE3_TOP) {
+        std::vector<std::pair<double, size_t>> ranked;
+        for (size_t c : finalists) {
+            auto it = std::find(survivors.begin(), survivors.end(), c);
+            if (it != survivors.end())
+                ranked.push_back({h_var2[it - survivors.begin()].first, c});
+        }
+        std::partial_sort(ranked.begin(), ranked.begin() + std::min(PHASE3_TOP, ranked.size()),
+                         ranked.end(), [](const auto& a, const auto& b) { return a.first > b.first; });
+        finalists.clear();
+        for (size_t i = 0; i < std::min(PHASE3_TOP, ranked.size()); i++)
+            finalists.push_back(ranked[i].second);
+    }
+    std::cerr << "→ " << finalists.size() << " finalists (Phase 3)\n";
+
+    /* Phase 3: largest sample, finalists only */
+    std::cerr << "Phase 3: " << PHASE3_SAMPLES << " quads, " << finalists.size() << " finalists... " << std::flush;
+    std::vector<std::array<size_t,4>> quads3 = use_stratification
+        ? sample_distinct_quads_stratified(equations, PHASE3_SAMPLES)
+        : sample_distinct_quads(n, PHASE3_SAMPLES);
+
+    std::vector<std::pair<double, size_t>> phase3_results;
+    for (size_t c : finalists) {
+        double h, v;
+        entropy_and_var_distinct(equations[c], equations, quads3, N, h, v);
+        phase3_results.push_back({h, c});
+    }
+    std::sort(phase3_results.begin(), phase3_results.end(),
+              [](const auto& a, const auto& b) { return a.first > b.first; });
+    std::cerr << "done.\n";
+
+    size_t best_idx = phase3_results[0].second;
+    double final_best_h = phase3_results[0].first;
+    std::vector<std::array<size_t,4>> quads_tb;  /* used if tiebreaker runs */
+    /* Tiebreaker: if top 2 are within epsilon, run larger sample on just them */
+    if (phase3_results.size() >= 2 &&
+        std::abs(phase3_results[0].first - phase3_results[1].first) < TIE_EPSILON) {
+        std::cerr << "Tiebreaker: top 2 within " << TIE_EPSILON << " bits, "
+                  << TIEBREAKER_SAMPLES << " quads... " << std::flush;
+        std::vector<size_t> top2 = {phase3_results[0].second, phase3_results[1].second};
+        quads_tb = use_stratification
+            ? sample_distinct_quads_stratified(equations, TIEBREAKER_SAMPLES)
+            : sample_distinct_quads(n, TIEBREAKER_SAMPLES);
+        double h0, h1, v0, v1;
+        entropy_and_var_distinct(equations[top2[0]], equations, quads_tb, N, h0, v0);
+        entropy_and_var_distinct(equations[top2[1]], equations, quads_tb, N, h1, v1);
+        best_idx = (h0 >= h1) ? top2[0] : top2[1];
+        final_best_h = (h0 >= h1) ? h0 : h1;
+        std::cerr << "winner: " << equations[best_idx] << "\n";
+    }
+
+    std::string best = equations[best_idx];
+    std::cout << "\nQuad Nerdle-optimal first guess: " << best
+              << " (entropy ≈ " << final_best_h << " bits)\n";
+
+    /* Report benchmarks on same sample as winner */
+    const auto& quads_bench = !quads_tb.empty() ? quads_tb : quads3;
+    size_t bench_n = quads_bench.size();
+    double h_single = 0, h_binerdle = 0, v_single, v_binerdle;
+    bool has_single = (single_idx < n), has_binerdle = (binerdle_idx < n);
+    if (has_single) {
+        entropy_and_var_distinct(single_first, equations, quads_bench, N, h_single, v_single);
+    }
+    if (has_binerdle) {
+        entropy_and_var_distinct(binerdle_first, equations, quads_bench, N, h_binerdle, v_binerdle);
+    }
+    std::cout << "Benchmark (same " << bench_n << " quads):\n";
+    if (has_single) std::cout << "  Single Nerdle: " << single_first << " (entropy ≈ " << h_single << " bits)\n";
+    if (has_binerdle) std::cout << "  Binerdle:      " << binerdle_first << " (entropy ≈ " << h_binerdle << " bits)\n";
+
+    return 0;
+}


### PR DESCRIPTION
### Summary

Adds support for [Quad Nerdle](https://www.nerdlegame.com/quadnerdle.html): four simultaneous equations in 10 tries, one shared guess per turn. Introduces new tools, fixes a solved-state bug in the interactive Quad player, and extends stratified sampling to Binerdle.

### New Tools

- **`quadnerdle`** — Interactive solver-assist for Quad Nerdle (similar to `binerdle`).
- **`solve_quadnerdle`** — Finds an optimal first guess with adaptive Monte Carlo.
- **`bench_quadnerdle`** — Benchmarks on sampled distinct quadruples (full enumeration of P(n,4) is infeasible).

### Why All Four Equations Are Distinct

Quad Nerdle uses four different equations. The search space is **P(n,4) = n×(n−1)×(n−2)×(n−3)**, not n⁴. Sampling and entropy estimation must enforce distinct indices; including repeated equations would skew the optimization and benchmarks.

### Why Stratified Sampling

Naive Monte Carlo can undersample some equation families (e.g. division-heavy or small-result). Stratified sampling groups equations by type (operator mix and result magnitude) and samples proportionally from each stratum. This:

1. Improves coverage of equation types.
2. Reduces variance for the same number of samples.
3. Stabilizes the ranking of guesses and helps the tiebreaker choose a single best first guess.

Classification uses 16 strata (operator mask + result bucket 0–9, 10–99, 100+). Stratification is used in `solve_quadnerdle`, the interactive `quadnerdle`, and the interactive `binerdle` when the candidate space exceeds 50k.

### Why the Adaptive Strategy in `solve_quadnerdle`

The P(n,4) space for len 8 (~9.86×10¹⁶ quadruples) is too large to enumerate. The approach mirrors `solve_adaptive`:

1. **Phase 1**: 5k stratified quads, evaluate all ~17k guesses, prune via confidence intervals.
2. **Phase 2**: 25k stratified quads on survivors.
3. **Phase 3**: Top ~50 by Phase 2, evaluated on 50k stratified quads.
4. **Tiebreaker**: If the top 2 are within 0.02 bits, run 200k stratified quads for a clearer winner.

This focuses compute on the best candidates instead of evaluating every equation on huge samples.

### Why Different Games Favor Different First Guesses

- **Single Nerdle**: Maximize H(fb); goal is even partitioning of the solution space.
- **Binerdle**: Maximize H(fb₁, fb₂) = H(fb₁) + H(fb₂|fb₁). A guess can be good for single Nerdle but induce correlated fb₁ and fb₂ when applied to two equations. `43-27=16` often performs better than `48-32=16` for pairs by making feedback less correlated.
- **Quad Nerdle**: Maximize H(fb₁, fb₂, fb₃, fb₄). We want each new feedback to add information. A guess that works across many equation structures (operators, digit patterns, result size) tends to perform better for Quads because it reduces correlation across the four feedback patterns. `1*15-9=6` is the Quad-optimal first guess; `43-27=16` and `48-32=16` are very close.

### Bug Fix: Solved State in Quad Nerdle

For equations already solved, feedback is computed as `compute_feedback(new_guess, solution)`, which is usually not all greens. The previous logic used `solved[i] = (f_i == "GGGGGGGG")`, so a new guess could incorrectly clear a solved equation. The fix is to only set `solved[i]` when it was not yet solved: `if (!solved[i]) solved[i] = (f_i == all_G);`.

### Binerdle Changes

- **Distinct pairs**: Entropy and best-guess selection use only pairs with different equations (i ≠ j).
- **Stratified sampling**: When the pair space is large, stratified Monte Carlo is used for the same reasons as in Quad Nerdle.

### Precomputed Results

**Quad Nerdle (len 8)**  
- Optimal: `1*15-9=6`  
- Close: `43-27=16`, `48-32=16`  

Run `./solve_quadnerdle data/equations_8.txt` to recompute (about 40–90 seconds); add `--no-stratify` for plain random sampling.