### PR TITLE
Fix static Maxi partition buckets and web engine UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,8 @@ data/*
 !data/equations_6.txt
 !data/equations_7.txt
 !data/equations_8.txt
-equations_*.txt
+!data/equations_10.txt
+/equations_*.txt
 
 # Python
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -65,19 +65,19 @@ browser_partition_data: browser_partition_artifacts micro_policy_web
 	./browser_partition_artifacts --pool data/equations_6.txt --kind classic --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_7.txt --kind classic --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind classic --out $(BROWSER_PARTITION_OUT)
-	./browser_partition_artifacts --pool data/equations_10.txt --kind classic --out $(BROWSER_PARTITION_OUT) --manifest-only
+	./browser_partition_artifacts --pool data/equations_10.txt --kind classic --out $(BROWSER_PARTITION_OUT) --opening-buckets-only
 	./browser_partition_artifacts --pool data/equations_6.txt --kind binerdle --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind binerdle --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind quad --out $(BROWSER_PARTITION_OUT)
 
-# Same as browser_partition_data but Maxi is a static manifest only (no data/equations_10.txt).
+# Same as browser_partition_data but Maxi skips canonical rank/full-pool output for fast Vercel builds.
 .PHONY: browser_partition_data_web
 browser_partition_data_web: browser_partition_artifacts micro_policy_web
 	./browser_partition_artifacts --pool data/equations_5.txt --kind classic --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_6.txt --kind classic --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_7.txt --kind classic --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind classic --out $(BROWSER_PARTITION_OUT)
-	./browser_partition_artifacts --write-maxi-manifest-only --out $(BROWSER_PARTITION_OUT)
+	./browser_partition_artifacts --pool data/equations_10.txt --kind classic --out $(BROWSER_PARTITION_OUT) --opening-buckets-only
 	./browser_partition_artifacts --pool data/equations_6.txt --kind binerdle --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind binerdle --out $(BROWSER_PARTITION_OUT)
 	./browser_partition_artifacts --pool data/equations_8.txt --kind quad --out $(BROWSER_PARTITION_OUT)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make                           # build C++ tools
 The static pages under `web/` run **in the browser only**: **partition** for all modes except Micro strategy choice; **Micro (5-tile)** adds **Bellman (optimal)** vs **partition** using `web/data/optimal_policy_5.bin`. There is no Python web server or `POST /api/step` in this UI.
 
 ```bash
-# One-shot: partition JSON + Micro policy + esbuild bundle (needs small pools in data/)
+# One-shot: partition JSON + Micro policy + esbuild bundle (needs pools in data/)
 make prepare_web_deploy
 # Same script: ./scripts/prepare_web_deploy.sh
 # After TS-only changes: ./scripts/prepare_web_deploy.sh --web-only
@@ -65,18 +65,16 @@ make prepare_web_deploy
 make browser_partition_artifacts
 make browser_partition_data_web
 cd web && npm install && npm run build
-# Full local regen including Maxi manifest from equations_10.txt:
-# make browser_partition_data
 # Optional: http://127.0.0.1:8123/ — npm run dev
 ```
 
-- **Artifacts:** `make browser_partition_data_web` writes `web/data/partition/{classic,binerdle,quad}_nN/` (see [docs/PARTITION_BROWSER_ARTIFACTS.md](docs/PARTITION_BROWSER_ARTIFACTS.md)) from tracked `data/equations_{5,6,7,8}.txt`, runs `micro_policy_web` (uses committed `web/data/optimal_policy_5.bin` or copies from `data/optimal_policy_5.bin` after `make micro_policy`). Maxi (`n=10`) is a static manifest only (`56+4-21=39`, pool size 2102375) — no `data/equations_10.txt` required. For a manifest derived from the live Maxi pool file, use `make browser_partition_data` locally.
+- **Artifacts:** `make browser_partition_data_web` writes `web/data/partition/{classic,binerdle,quad}_nN/` (see [docs/PARTITION_BROWSER_ARTIFACTS.md](docs/PARTITION_BROWSER_ARTIFACTS.md)) from tracked `data/equations_{5,6,7,8,10}.txt`, runs `micro_policy_web` (uses committed `web/data/optimal_policy_5.bin` or copies from `data/optimal_policy_5.bin` after `make micro_policy`). Maxi (`n=10`) generates opening feedback buckets without `pool_full.json`, so the static UI can continue after the recommended first guess without committing generated bucket files.
 - **Regression check:** `npm run validate:partition --prefix web` compares the browser partition engine to `./solver_json` (the binary is only used for that test, not by the UI).
 - **Strategies (web):** Bellman = precomputed Micro policy; partition = browser partition engine for all lengths/modes.
 
 ### Deploying to Vercel (GitHub)
 
-1. **Commit** source and small inputs: `data/equations_{5,6,7,8}.txt`, `web/data/optimal_policy_5.bin`, `web/src/**`, `Makefile`, `src/browser_partition_artifacts.cpp`, `scripts/prepare_web_deploy.sh`, `web/package*.json`, etc. Do **not** commit generated `web/data/partition/**` or `web/app.bundle.js` (they are gitignored; Vercel creates them at build time).
+1. **Commit** source and small inputs: `data/equations_{5,6,7,8,10}.txt`, `web/data/optimal_policy_5.bin`, `web/src/**`, `Makefile`, `src/browser_partition_artifacts.cpp`, `scripts/prepare_web_deploy.sh`, `web/package*.json`, etc. Do **not** commit generated `web/data/partition/**` or `web/app.bundle.js` (they are gitignored; Vercel creates them at build time).
 2. In Vercel: **Import** the repo → **Root Directory**: `.` (repository root) → Framework: **Other**. Either rely on [vercel.json](vercel.json) or set manually:
    - **Install Command**: `npm ci --prefix web`
    - **Build Command**: `bash ./scripts/prepare_web_deploy.sh`

--- a/docs/PARTITION_BROWSER_ARTIFACTS.md
+++ b/docs/PARTITION_BROWSER_ARTIFACTS.md
@@ -2,7 +2,7 @@
 
 Static files under `web/data/partition/` power the browser-only partition solver.
 
-They are **generated** by `make browser_partition_data_web` (CI/Vercel-friendly: uses `data/equations_{5,6,7,8}.txt` and a static Maxi manifest) or `make browser_partition_data` (includes Maxi manifest derived from `data/equations_10.txt` via `--manifest-only`). Generated output is normally **not** committed; run `./scripts/prepare_web_deploy.sh` locally or on the host that builds static assets.
+They are **generated** by `make browser_partition_data_web` (CI/Vercel-friendly: uses tracked `data/equations_{5,6,7,8,10}.txt`). Generated output is normally **not** committed; run `./scripts/prepare_web_deploy.sh` locally or on the host that builds static assets.
 
 ## Layout
 
@@ -32,7 +32,7 @@ web/data/partition/
 }
 ```
 
-- Maxi (`n=10`): `hasPoolFull` is false, `hasOpeningBuckets` is false; the static UI exposes only the recommended first guess (`56+4-21=39`). Post-opening play is not supported without full buckets.
+- Maxi (`n=10`): `hasPoolFull` is false and `hasOpeningBuckets` is true. The static UI requires the recommended first guess (`56+4-21=39`), then loads the matching opening-feedback bucket for post-opening play.
 
 ## Bucket file `b/{code}.json`
 
@@ -43,7 +43,7 @@ JSON array of rows, each row:
 ```
 
 - `id`: 0-based index into `data/equations_{N}.txt` (after maxi normalization in the generator).
-- `rank`: canonical tie-break rank (0 = best); matches `canonical_less` order on the full pool.
+- `rank`: canonical tie-break rank (0 = best); matches `canonical_less` order on the full pool for n≤8. Maxi opening-bucket rows use the equation id here because browser Classic post-opening selection does not need canonical rank.
 - `equation`: display string (UTF-8 `²`/`³` for maxi).
 
 Rows are sorted by `id` ascending.

--- a/scripts/prepare_web_deploy.sh
+++ b/scripts/prepare_web_deploy.sh
@@ -31,6 +31,7 @@ else
     data/equations_6.txt
     data/equations_7.txt
     data/equations_8.txt
+    data/equations_10.txt
   )
   for f in "${pools[@]}"; do
     if [[ ! -f "$f" ]]; then

--- a/src/browser_partition_artifacts.cpp
+++ b/src/browser_partition_artifacts.cpp
@@ -4,7 +4,7 @@
  * Usage:
  *   ./browser_partition_artifacts --pool data/equations_8.txt --kind classic --out web/data/partition
  *   ./browser_partition_artifacts --pool data/equations_6.txt --kind binerdle --out web/data/partition
- *   ./browser_partition_artifacts --pool data/equations_10.txt --kind classic --out web/data/partition --manifest-only
+ *   ./browser_partition_artifacts --pool data/equations_10.txt --kind classic --out web/data/partition --opening-buckets-only
  *   ./browser_partition_artifacts --write-maxi-manifest-only --out web/data/partition
  *
  * For each (pool, opening from partition_fixed_opening_tie6), writes:
@@ -126,6 +126,7 @@ int main(int argc, char** argv) {
     std::string kind = "classic";
     std::string out_root = "web/data/partition";
     bool manifest_only = false;
+    bool opening_buckets_only = false;
     bool write_maxi_manifest_only = false;
 
     for (int i = 1; i < argc; i++) {
@@ -138,11 +139,13 @@ int main(int argc, char** argv) {
             out_root = argv[++i];
         else if (a == "--manifest-only")
             manifest_only = true;
+        else if (a == "--opening-buckets-only")
+            opening_buckets_only = true;
         else if (a == "--write-maxi-manifest-only")
             write_maxi_manifest_only = true;
         else if (a == "-h" || a == "--help") {
             std::cerr << "Usage: browser_partition_artifacts --pool data/equations_N.txt [--kind classic|binerdle|quad] "
-                         "[--out web/data/partition] [--manifest-only]\n"
+                         "[--out web/data/partition] [--manifest-only|--opening-buckets-only]\n"
                          "       browser_partition_artifacts --write-maxi-manifest-only [--out web/data/partition]\n";
             return 1;
         }
@@ -273,6 +276,53 @@ int main(int argc, char** argv) {
 
         std::cout << "Wrote manifest-only artifact under " << subdir << " (opening "
                   << opening_display << ", pool " << equations.size() << ")\n";
+        return 0;
+    }
+
+    if (opening_buckets_only) {
+        std::filesystem::remove(subdir + "/pool_full.json");
+        ensure_dir(subdir + "/b");
+
+        std::unordered_map<uint32_t, std::vector<size_t>> buckets;
+        for (size_t si = 0; si < equations.size(); si++) {
+            uint32_t code = nerdle::compute_feedback_packed(opening, equations[si], N);
+            buckets[code].push_back(si);
+        }
+
+        for (auto& kv : buckets) {
+            uint32_t code = kv.first;
+            auto& vec = kv.second;
+            std::sort(vec.begin(), vec.end());
+
+            std::ostringstream body;
+            body << "[\n";
+            for (size_t i = 0; i < vec.size(); i++) {
+                size_t id = vec[i];
+                std::string disp = is_maxi ? maxi_to_display(equations[id]) : equations[id];
+                body << "  [" << id << "," << id << "," << json_escape(disp) << "]";
+                if (i + 1 < vec.size())
+                    body << ",";
+                body << "\n";
+            }
+            body << "]";
+            write_file(subdir + "/b/" + std::to_string(code) + ".json", body.str());
+        }
+
+        std::ostringstream man;
+        man << "{\n";
+        man << "  \"version\": 1,\n";
+        man << "  \"kind\": " << json_escape(kind) << ",\n";
+        man << "  \"n\": " << N << ",\n";
+        man << "  \"opening\": " << json_escape(opening_display) << ",\n";
+        man << "  \"poolSize\": " << equations.size() << ",\n";
+        man << "  \"bucketDir\": \"b\",\n";
+        man << "  \"hasPoolFull\": false,\n";
+        man << "  \"hasOpeningBuckets\": true\n";
+        man << "}\n";
+        write_file(subdir + "/manifest.json", man.str());
+
+        std::cout << "Wrote " << buckets.size() << " opening buckets under " << subdir << " (opening "
+                  << opening_display << ")\n";
         return 0;
     }
 

--- a/web/app.js
+++ b/web/app.js
@@ -34,6 +34,8 @@
   let cursor = 0;
   /** Which board receives g/p/b when using keyboard (click a tile to focus a board). */
   let activeBoard = 0;
+  /** `"board,col"` of the tile last selected by click; repeat click on that tile cycles color. Cleared when highlight moves by keyboard/typing. */
+  let lastPointerTileKey = null;
   /** @type {('G'|'P'|'B')[][]} */
   let feedback = Array.from({ length: numBoards }, () => Array(n).fill("B"));
   /** @type {object[]} */
@@ -70,10 +72,15 @@
   }
 
   function guessHintText() {
+    const nav =
+      numBoards > 1
+        ? "Arrow keys ← → move the highlighted cell (wraps across boards); ↑ ↓ switch boards at the same column. "
+        : "Arrow keys ← → move the highlighted cell. ";
     return (
-      "Click a tile to focus it and cycle teal → purple → black. Type digits/symbols from the keypad. " +
+      nav +
+      "Click a tile to select it; click again to cycle teal → purple → black. Type digits/symbols from the keypad. " +
       "Slots that must still be green from your past guesses default to teal; others default to black. " +
-      "Keys g, p, b set color and move right."
+      "Keys g, p, b set color and move right. Backspace clears tile color; Delete erases the typed character."
     );
   }
 
@@ -161,7 +168,27 @@
   }
 
   function advanceCursor() {
-    cursor = (cursor + 1) % n;
+    moveHighlight(1);
+  }
+
+  /** Move the feedback highlight: one step along boards×columns (left = −1, right = +1), wrapping the full grid. */
+  function moveHighlight(delta) {
+    lastPointerTileKey = null;
+    if (numBoards === 1) {
+      cursor = (cursor + delta + n) % n;
+      return;
+    }
+    const total = numBoards * n;
+    let linear = activeBoard * n + cursor;
+    linear = (linear + delta + total) % total;
+    activeBoard = Math.floor(linear / n);
+    cursor = linear % n;
+  }
+
+  function moveActiveBoard(delta) {
+    if (numBoards <= 1) return;
+    lastPointerTileKey = null;
+    activeBoard = (activeBoard + delta + numBoards) % numBoards;
   }
 
   function renderCombinedBoards() {
@@ -188,12 +215,22 @@
         span.className = "tile-char";
         span.textContent = guessCells[i] || "·";
         t.appendChild(span);
-        t.title = "Click: cycle teal → purple → black";
+        t.title = "First click selects; later clicks cycle teal → purple → black";
         t.addEventListener("click", (ev) => {
           ev.preventDefault();
+          const tileKey = `${b},${i}`;
           activeBoard = b;
           cursor = i;
-          cycleFeedback(b, i);
+          try {
+            els.combinedBoards.focus({ preventScroll: true });
+          } catch (_) {
+            els.combinedBoards.focus();
+          }
+          if (lastPointerTileKey === tileKey) {
+            cycleFeedback(b, i);
+          } else {
+            lastPointerTileKey = tileKey;
+          }
           renderCombinedBoards();
         });
         row.appendChild(t);
@@ -220,7 +257,7 @@
     bs.type = "button";
     bs.textContent = "\u232b";
     bs.className = "key-wide";
-    bs.addEventListener("click", backspace);
+    bs.addEventListener("click", () => deleteDigit());
     els.keypad.appendChild(bs);
     const clr = document.createElement("button");
     clr.type = "button";
@@ -229,6 +266,7 @@
     clr.addEventListener("click", () => {
       guessCells = Array(n).fill("");
       cursor = 0;
+      lastPointerTileKey = null;
       feedback = Array.from({ length: numBoards }, () => Array(n).fill("B"));
       applyFeedbackDefaults();
       renderCombinedBoards();
@@ -237,6 +275,7 @@
   }
 
   function typeKey(k) {
+    lastPointerTileKey = null;
     if (cursor >= n) cursor = n - 1;
     guessCells[cursor] = k;
     cursor = Math.min(n - 1, cursor + 1);
@@ -244,7 +283,17 @@
     renderCombinedBoards();
   }
 
-  function backspace() {
+  /** Keyboard Backspace: clear feedback color on the highlighted tile (then re-apply history defaults). */
+  function backspaceFeedback() {
+    lastPointerTileKey = null;
+    feedback[activeBoard][cursor] = "B";
+    applyFeedbackDefaults();
+    renderCombinedBoards();
+  }
+
+  /** Keyboard Delete / keypad ⌫: erase guess character at the highlight (or step left if empty). */
+  function deleteDigit() {
+    lastPointerTileKey = null;
     if (guessCells[cursor]) {
       guessCells[cursor] = "";
     } else if (cursor > 0) {
@@ -291,39 +340,40 @@
     }
   }
 
-  async function refreshEngine() {
-    showError("");
-    const hist = historyPayload();
-
+  async function solveHistory(hist) {
     if (isMicroClassic && strategy === "bellman" && typeof window.nerdleMicroBellmanClassic === "function") {
       try {
         const data = await window.nerdleMicroBellmanClassic("", hist);
-        if (data.ok) {
-          applySolverResponse(data);
-          return;
-        }
-        showError(data.error || "");
+        if (data.ok) return data;
+        return data;
       } catch (e) {
-        showError(String(e));
+        return { ok: false, error: String(e) };
       }
-      return;
+    }
+
+    if (isMicroClassic && strategy === "bellman") {
+      return { ok: false, error: "Micro Bellman engine not loaded (build web bundle: cd web && npm run build)." };
     }
 
     if (typeof window.nerdleBrowserPartition === "function") {
       try {
-        const data = await window.nerdleBrowserPartition("", kind, n, hist);
-        if (data.ok) {
-          applySolverResponse(data);
-          return;
-        }
-        showError(data.error || "");
+        return await window.nerdleBrowserPartition("", kind, n, hist);
       } catch (e) {
-        showError(String(e));
+        return { ok: false, error: String(e) };
       }
-      return;
     }
 
-    showError("Browser engine not loaded (build web bundle: cd web && npm run build).");
+    return { ok: false, error: "Browser engine not loaded (build web bundle: cd web && npm run build)." };
+  }
+
+  async function refreshEngine() {
+    showError("");
+    const data = await solveHistory(historyPayload());
+    if (data.ok) {
+      applySolverResponse(data);
+      return;
+    }
+    showError(data.error || "request failed");
   }
 
   function renderHistory() {
@@ -337,7 +387,7 @@
     });
   }
 
-  function submitRow() {
+  async function submitRow() {
     showError("");
     if (guessCells.some((c) => !c)) {
       showError(`Fill all ${n} guess tiles.`);
@@ -348,14 +398,25 @@
       kind === "classic"
         ? { guess: g, feedback: feedback[0].join("") }
         : { guess: g, feedbacks: feedback.map((row) => row.join("")) };
+    const proposedHistory = historyPayload().concat(
+      kind === "classic"
+        ? { guess: entry.guess, feedback: entry.feedback }
+        : { guess: entry.guess, feedback: entry.feedbacks }
+    );
+    const data = await solveHistory(proposedHistory);
+    if (!data.ok) {
+      showError(data.error || "No candidates remain — check guess and feedback.");
+      return;
+    }
     history.push(entry);
     guessCells = Array(n).fill("");
     cursor = 0;
+    lastPointerTileKey = null;
     feedback = Array.from({ length: numBoards }, () => Array(n).fill("B"));
     applyFeedbackDefaults();
     renderCombinedBoards();
     renderHistory();
-    refreshEngine();
+    applySolverResponse(data);
   }
 
   function resetAll() {
@@ -363,6 +424,7 @@
     guessCells = Array(n).fill("");
     cursor = 0;
     activeBoard = 0;
+    lastPointerTileKey = null;
     feedback = Array.from({ length: numBoards }, () => Array(n).fill("B"));
     applyFeedbackDefaults();
     renderCombinedBoards();
@@ -387,19 +449,36 @@
     }
     if (key === "ArrowLeft") {
       ev.preventDefault();
-      cursor = (cursor - 1 + n) % n;
+      moveHighlight(-1);
       renderCombinedBoards();
       return;
     }
     if (key === "ArrowRight") {
       ev.preventDefault();
-      advanceCursor();
+      moveHighlight(1);
+      renderCombinedBoards();
+      return;
+    }
+    if (key === "ArrowUp") {
+      ev.preventDefault();
+      moveActiveBoard(-1);
+      renderCombinedBoards();
+      return;
+    }
+    if (key === "ArrowDown") {
+      ev.preventDefault();
+      moveActiveBoard(1);
       renderCombinedBoards();
       return;
     }
     if (key === "Backspace") {
       ev.preventDefault();
-      backspace();
+      backspaceFeedback();
+      return;
+    }
+    if (key === "Delete") {
+      ev.preventDefault();
+      deleteDigit();
       return;
     }
     const map = {
@@ -432,23 +511,30 @@
   }
 
   /* init */
+  els.combinedBoards.tabIndex = 0;
+  els.combinedBoards.setAttribute("role", "grid");
+  els.combinedBoards.setAttribute("aria-label", "Current guess and per-tile feedback");
+
   els.title.textContent = modeTitle();
   document.title = modeTitle() + " — engine";
   els.strategyHint.textContent = strategyHintText();
   els.guessHint.textContent = guessHintText();
 
-  if (!isMicroClassic) {
-    els.strategyToggle.hidden = true;
-  } else {
+  els.strategyToggle.hidden = !isMicroClassic;
+  els.btnBellman.hidden = !isMicroClassic;
+  if (isMicroClassic) {
     els.btnBellman.addEventListener("click", () => setStrategy("bellman"));
     els.btnPartition.addEventListener("click", () => setStrategy("partition"));
     els.btnBellman.classList.toggle("active", strategy === "bellman");
     els.btnPartition.classList.toggle("active", strategy === "partition");
+  } else {
+    els.btnPartition.classList.add("active");
   }
 
   els.btnApply.addEventListener("click", () => {
     const s = els.suggestion.textContent.trim();
     if (!s || s === "—") return;
+    lastPointerTileKey = null;
     guessCells = splitGuessString(s);
     while (guessCells.length < n) guessCells.push("");
     guessCells = guessCells.slice(0, n);

--- a/web/engine.html
+++ b/web/engine.html
@@ -19,8 +19,8 @@
       <div class="panel">
         <h3>Solver input</h3>
         <div class="toolbar">
-          <div class="strategy-toggle" id="strategy-toggle">
-            <button type="button" data-strat="bellman" id="btn-bellman">Bellman (optimal)</button>
+          <div class="strategy-toggle" id="strategy-toggle" hidden>
+            <button type="button" data-strat="bellman" id="btn-bellman" hidden>Bellman (optimal)</button>
             <button type="button" data-strat="partition" id="btn-partition">Partition</button>
           </div>
           <button type="button" class="btn btn-ghost" id="btn-reset">Reset</button>
@@ -53,7 +53,7 @@
         <div class="remaining-box" id="remaining">—</div>
         <p class="strategy-hint" id="remaining-note"></p>
         <footer class="note" style="margin-top:1rem">
-          Teal = correct spot, purple = wrong spot, black = not in equation. Click tiles to cycle colors; keys <kbd>g</kbd> <kbd>p</kbd> <kbd>b</kbd> set color and move right.
+          Teal = correct spot, purple = wrong spot, black = not in equation. First click on a tile selects it; later clicks cycle colors. <kbd>←</kbd> <kbd>→</kbd> move the highlight (wraps across boards in multi-board modes); <kbd>g</kbd> <kbd>p</kbd> <kbd>b</kbd> set color and move right. <kbd>Backspace</kbd> clears tile color; <kbd>Delete</kbd> erases the character; keypad ⌫ erases the character.
         </footer>
       </div>
     </div>

--- a/web/src/artifacts.ts
+++ b/web/src/artifacts.ts
@@ -38,6 +38,7 @@ export async function fetchBucket(baseUrl: string, kind: string, n: number, feed
   const key = manifestKey(kind, n);
   const url = joinDataPath(baseUrl, `data/partition/${key}/b/${feedbackCode}.json`);
   const res = await fetch(url);
+  if (res.status === 404) return [];
   if (!res.ok) throw new Error(`bucket ${url}: ${res.status}`);
   return (await res.json()) as BucketRow[];
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -311,7 +311,17 @@ main {
 .tile.combined.tile-cursor-active {
   outline: 3px solid var(--green-bright);
   outline-offset: 1px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
   z-index: 1;
+}
+
+#combined-boards:focus {
+  outline: none;
+}
+
+#combined-boards:focus-visible {
+  box-shadow: 0 0 0 2px var(--green-bright);
+  border-radius: 6px;
 }
 
 .board-block {


### PR DESCRIPTION
## Summary
- Generate Maxi (`n=10`) opening-feedback buckets at deploy time from tracked `data/equations_10.txt` (fast `--opening-buckets-only` path) so static deploys work after the first guess.
- Document and wire deploy prep / `.gitignore` for the Maxi pool.
- Web engine: empty bucket 404 handling, keyboard/UI polish (arrows, Backspace vs Delete, tile click to select then cycle), Bellman toggle only for Micro.

## Test plan
- `make browser_partition_data_web` / `./scripts/prepare_web_deploy.sh`
- `cd web && npm run build`


Made with [Cursor](https://cursor.com)